### PR TITLE
Improve language-aware recommendations

### DIFF
--- a/MoodTunes/Models/SaraResponse.swift
+++ b/MoodTunes/Models/SaraResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct SaraResponse {
+    let reply: String
+    let vibe: String
+    let language: String
+    let scene: String
+    let keywords: [String]
+}

--- a/MoodTunes/Services/TogetherService.swift
+++ b/MoodTunes/Services/TogetherService.swift
@@ -3,9 +3,10 @@ import Foundation
 class TogetherService {
     static let shared = TogetherService()
 
-    func askSara(userInput: String, languageTags: [String], completion: @escaping (String, [String]) -> Void) {
+    func askSara(userInput: String, languageTags: [String], completion: @escaping (SaraResponse) -> Void) {
         guard let url = URL(string: "https://api.together.xyz/v1/chat/completions") else {
-            completion("Sorry, couldn't connect to Sara.", [])
+            let fallback = SaraResponse(reply: "Sorry, couldn't connect to Sara.", vibe: "", language: "", scene: "", keywords: [])
+            completion(fallback)
             return
         }
 
@@ -15,9 +16,12 @@ class TogetherService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let prompt = """
-        You are Sara, a Gen-Z music therapist who replies in exactly 2 comforting lines. The user shares a situation, and you must gently reflect on it. Do NOT suggest songs in text. Instead, extract 3 strong keywords (emotions, similar movie situation resemblance, moods) at the end of your reply in this format:
+        You are Sara, a Gen-Z music therapist who replies in exactly 2 comforting lines. The user shares a situation and you gently reflect on it. Do NOT suggest songs directly. After your two line response add details using this exact format:
 
         ---
+        vibe: <short vibe description>
+        language: <language of recommended songs>
+        scene: <Bollywood movie scene with a similar situation>
         keywords: [keyword1, keyword2, keyword3]
 
         User message: "\(userInput)"
@@ -37,7 +41,8 @@ class TogetherService {
 
         URLSession.shared.dataTask(with: request) { data, _, error in
             guard let data = data else {
-                completion("Sorry, Sara couldn’t reply.", [])
+                let fallback = SaraResponse(reply: "Sorry, Sara couldn’t reply.", vibe: "", language: "", scene: "", keywords: [])
+                completion(fallback)
                 return
             }
 
@@ -46,21 +51,43 @@ class TogetherService {
                 let reply = (json?["choices"] as? [[String: Any]])?.first?["message"] as? [String: Any]
                 let fullReply = reply?["content"] as? String ?? "Sara's lost in thought..."
 
-                // 🧠 Extract Sara's text and keywords (from `keywords: [...]`)
-                let lines = fullReply.components(separatedBy: "---")
-                let replyText = lines.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "Hmm..."
-                let keywordLine = lines.last ?? ""
-                let keywordMatch = keywordLine
-                    .components(separatedBy: "[")
-                    .last?
-                    .components(separatedBy: "]")
-                    .first?
-                    .components(separatedBy: ",")
-                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? []
+                // 🧠 Extract Sara's text and metadata
+                let sections = fullReply.components(separatedBy: "---")
+                let replyText = sections.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "Hmm..."
 
-                completion(replyText, keywordMatch)
+                var vibe = ""
+                var language = ""
+                var scene = ""
+                var keywords: [String] = []
+
+                if sections.count > 1 {
+                    let metaLines = sections[1].components(separatedBy: "\n")
+                    for line in metaLines {
+                        let trimmed = line.trimmingCharacters(in: .whitespaces)
+                        if trimmed.lowercased().hasPrefix("vibe:") {
+                            vibe = trimmed.replacingOccurrences(of: "vibe:", with: "").trimmingCharacters(in: .whitespaces)
+                        } else if trimmed.lowercased().hasPrefix("language:") {
+                            language = trimmed.replacingOccurrences(of: "language:", with: "").trimmingCharacters(in: .whitespaces)
+                        } else if trimmed.lowercased().hasPrefix("scene:") {
+                            scene = trimmed.replacingOccurrences(of: "scene:", with: "").trimmingCharacters(in: .whitespaces)
+                        } else if trimmed.lowercased().hasPrefix("keywords:") {
+                            let keywordLine = trimmed
+                                .components(separatedBy: "[")
+                                .last?
+                                .components(separatedBy: "]")
+                                .first?
+                            if let line = keywordLine {
+                                keywords = line.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                            }
+                        }
+                    }
+                }
+
+                let response = SaraResponse(reply: replyText, vibe: vibe, language: language, scene: scene, keywords: keywords)
+                completion(response)
             } catch {
-                completion("Sara glitched out 🫠", [])
+                let fallback = SaraResponse(reply: "Sara glitched out 🫠", vibe: "", language: "", scene: "", keywords: [])
+                completion(fallback)
             }
         }.resume()
     }


### PR DESCRIPTION
## Summary
- add `SaraResponse` model for structured chat metadata
- extend TogetherService to return vibe, language, scene and keywords
- update ChatView to display recommendations using the new metadata

## Testing
- `swift --version`
- `for f in $(find MoodTunes -name "*.swift"); do swiftc -swift-version 5 -target x86_64-apple-macosx13.0 -parse-as-library -c $f; done` *(fails: unable to load standard library)*

------
https://chatgpt.com/codex/tasks/task_e_685e75fe071c832a8d436c013c52ff1f