### PR TITLE
Improve Sara's song suggestions

### DIFF
--- a/MoodTunes/Models/SuggestedTrack.swift
+++ b/MoodTunes/Models/SuggestedTrack.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct SuggestedTrack: Identifiable {
+    let track: Track
+    let reason: String
+    var id: String { track.id }
+}


### PR DESCRIPTION
## Summary
- add `SuggestedTrack` model for per-song context
- show song reasoning using `SuggestedTrack`
- fetch songs individually based on keywords
- pass tracks correctly to `NowPlayingView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e79d36b08832aaf8c98b6571d81ec