### PR TITLE
Refactor Sara chat and song recommendations

### DIFF
--- a/MoodTunes/Models/SaraResponse.swift
+++ b/MoodTunes/Models/SaraResponse.swift
@@ -2,8 +2,4 @@ import Foundation
 
 struct SaraResponse {
     let reply: String
-    let vibe: String
-    let language: String
-    let scene: String
-    let keywords: [String]
 }


### PR DESCRIPTION
## Summary
- simplify `SaraResponse` to only include the reply text
- adjust TogetherService prompt and parsing for two-line reply only
- update ChatView to fetch songs using user's situation and languages

## Testing
- `swiftc $(find MoodTunes -name '*.swift') -o MoodTunesAppExecutable` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685f22aa488c832aab243ab5b9fbfb68