### PR TITLE
Add deletion buttons for songs and playlists

### DIFF
--- a/MoodTunes/Views/ChatView.swift
+++ b/MoodTunes/Views/ChatView.swift
@@ -30,12 +30,16 @@ struct ChatView: View {
                             MessageBubbleView(message: message)
                         }
 
-                        ForEach(suggestedTracks) { suggestion in
+                        ForEach(suggestedTracks.indices, id: \.self) { index in
+                            let suggestion = suggestedTracks[index]
                             SongCard(
                                 track: suggestion.track,
                                 reason: suggestion.reason,
                                 onTap: {
                                     selectedTrack = suggestion.track
+                                },
+                                onDelete: {
+                                    suggestedTracks.remove(at: index)
                                 }
                             )
                         }

--- a/MoodTunes/Views/Components/SongCard.swift
+++ b/MoodTunes/Views/Components/SongCard.swift
@@ -4,45 +4,54 @@ struct SongCard: View {
     let track: Track
     let reason: String
     let onTap: () -> Void
+    var onDelete: (() -> Void)? = nil
 
     var body: some View {
-        Button(action: onTap) {
-            HStack(spacing: 12) {
-                // Album Cover
-                AsyncImage(url: URL(string: track.coverURL)) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                } placeholder: {
-                    Color.gray.opacity(0.3)
-                }
-                .frame(width: 60, height: 60)
-                .cornerRadius(8)
-
-                // Song Info
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(track.title)
-                        .font(.headline)
-                        .foregroundColor(.primary)
-
-                    Text(track.artist)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-
-                    Text(reason)
-                        .font(.caption)
-                        .foregroundColor(.blue)
-                }
-
-                Spacer()
-
-                // Play Icon
-                Image(systemName: "play.circle.fill")
-                    .foregroundColor(.green)
-                    .font(.title2)
+        HStack(spacing: 12) {
+            // Album Cover
+            AsyncImage(url: URL(string: track.coverURL)) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                Color.gray.opacity(0.3)
             }
-            .padding(.vertical, 8)
+            .frame(width: 60, height: 60)
+            .cornerRadius(8)
+
+            // Song Info
+            VStack(alignment: .leading, spacing: 4) {
+                Text(track.title)
+                    .font(.headline)
+                    .foregroundColor(.primary)
+
+                Text(track.artist)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                Text(reason)
+                    .font(.caption)
+                    .foregroundColor(.blue)
+            }
+
+            Spacer()
+
+            // Play Icon
+            Image(systemName: "play.circle.fill")
+                .foregroundColor(.green)
+                .font(.title2)
+
+            if let onDelete = onDelete {
+                Button(action: onDelete) {
+                    Image(systemName: "trash.circle.fill")
+                        .foregroundColor(.red)
+                        .font(.title2)
+                }
+                .buttonStyle(.plain)
+            }
         }
-        .buttonStyle(PlainButtonStyle())
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
     }
 }

--- a/MoodTunes/Views/LibraryView.swift
+++ b/MoodTunes/Views/LibraryView.swift
@@ -40,6 +40,13 @@ struct LibraryView: View {
                         }
                         .padding(.vertical, 6)
                     }
+                    .swipeActions {
+                        Button(role: .destructive) {
+                            libraryVM.playlists.remove(at: index)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
                 }
             }
             .navigationTitle("🎧 Your Library")


### PR DESCRIPTION
## Summary
- allow SongCard to show a delete button
- let ChatView remove suggested songs
- enable playlist removal in LibraryView via swipe action

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f36b5ce40832ab6a697abb38b904c