### PR TITLE
Add SoundCloud service

### DIFF
--- a/MoodTunes/Services/SoundCloudService.swift
+++ b/MoodTunes/Services/SoundCloudService.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+class SoundCloudService {
+    static let shared = SoundCloudService()
+
+    private let headers = [
+        "X-RapidAPI-Key": Secrets.rapidAPIkey,
+        "X-RapidAPI-Host": "soundcloud4.p.rapidapi.com"
+    ]
+
+    func searchTracks(query: String, completion: @escaping ([Track]) -> Void) {
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://soundcloud4.p.rapidapi.com/search?query=\(encoded)&limit=10") else {
+            completion([])
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.allHTTPHeaderFields = headers
+
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            guard let data = data else {
+                completion([])
+                return
+            }
+
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let tracks = json["tracks"] as? [[String: Any]] {
+                    let results: [Track] = tracks.compactMap { item in
+                        guard let id = item["id"] as? Int,
+                              let title = item["title"] as? String,
+                              let user = item["user"] as? [String: Any],
+                              let artistName = user["username"] as? String else {
+                            return nil
+                        }
+                        let artwork = item["artwork_url"] as? String ?? ""
+                        return Track(id: String(id), title: title, artist: artistName, coverURL: artwork)
+                    }
+                    completion(results)
+                } else {
+                    completion([])
+                }
+            } catch {
+                completion([])
+            }
+        }.resume()
+    }
+}

--- a/MoodTunes/Views/DiscoverView.swift
+++ b/MoodTunes/Views/DiscoverView.swift
@@ -82,7 +82,7 @@ struct DiscoverView: View {
         results = []
         selectedTrack = nil
 
-        SpotifyService.shared.searchTracks(query: query) { tracks in
+        SoundCloudService.shared.searchTracks(query: query) { tracks in
             DispatchQueue.main.async {
                 self.results = tracks
                 self.isLoading = false


### PR DESCRIPTION
## Summary
- add a new `SoundCloudService` using RapidAPI
- switch DiscoverView to perform searches with SoundCloud

## Testing
- `swift --version`
- `swift build` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_685f4142880c832aa580cce0f04b106c