### PR TITLE
Use SoundCloud API across views

### DIFF
--- a/MoodTunes/Views/ChatView.swift
+++ b/MoodTunes/Views/ChatView.swift
@@ -120,7 +120,7 @@ struct ChatView: View {
 
     func fetchSongs(for situation: String) {
         let query = ([situation] + Array(selectedLanguages)).joined(separator: " ")
-        SpotifyService.shared.searchTracks(query: query) { tracks in
+        SoundCloudService.shared.searchTracks(query: query) { tracks in
             let reasons = "Songs in " + selectedLanguages.joined(separator: ", ")
             let suggestions = tracks.prefix(10).map { SuggestedTrack(track: $0, reason: reasons) }
             DispatchQueue.main.async {

--- a/MoodTunes/Views/HomeView.swift
+++ b/MoodTunes/Views/HomeView.swift
@@ -190,13 +190,13 @@ struct HomeView: View {
                 }
             }
             .onAppear {
-                SpotifyService.shared.fetchPopularArtists { artists in
+                SoundCloudService.shared.fetchPopularArtists { artists in
                     self.popularArtists = artists
                 }
-                SpotifyService.shared.fetchBollywoodAlbums { albums in
+                SoundCloudService.shared.fetchBollywoodAlbums { albums in
                     self.bollywoodAlbums = albums
                 }
-                SpotifyService.shared.searchTracks(query: "Taylor Swift") { tracks in
+                SoundCloudService.shared.searchTracks(query: "Taylor Swift") { tracks in
                     self.taylorTracks = tracks
                 }
             }

--- a/MoodTunes/Views/LibraryView.swift
+++ b/MoodTunes/Views/LibraryView.swift
@@ -137,7 +137,7 @@ struct PlaylistDetailView: View {
 
         for query in playlist.queries {
             group.enter()
-            SpotifyService.shared.searchTracks(query: query) { result in
+            SoundCloudService.shared.searchTracks(query: query) { result in
                 allFetched.append(contentsOf: result)
                 group.leave()
             }

--- a/MoodTunes/Views/NowPlayingView.swift
+++ b/MoodTunes/Views/NowPlayingView.swift
@@ -136,7 +136,7 @@ struct NowPlayingView: View {
     func play(_ track: Track) {
         player?.pause() // ✅ Stop previous playback
 
-        SpotifyService.shared.fetchPreviewURL(for: track.id) { url in
+        SoundCloudService.shared.fetchStreamURL(for: track.id) { url in
             if let url = url, let audioURL = URL(string: url) {
                 DispatchQueue.main.async {
                     player = AVPlayer(url: audioURL)


### PR DESCRIPTION
## Summary
- switch chat, home, library and playback views from SpotifyService to SoundCloudService
- extend SoundCloudService with helpers for streaming, artists and albums

## Testing
- `swiftc -parse MoodTunes/Services/SoundCloudService.swift`
- `swiftc -parse MoodTunes/Views/NowPlayingView.swift`
- `swiftc -parse MoodTunes/Views/ChatView.swift`
- `swiftc -parse MoodTunes/Views/LibraryView.swift`
- `swiftc -parse MoodTunes/Views/HomeView.swift`


------
https://chatgpt.com/codex/tasks/task_e_685f42bff7d0832a965beb4cbd1b4e87