### PR TITLE
Add Siri Shortcuts support

### DIFF
--- a/MoodTunes/App/MoodTunesApp.swift
+++ b/MoodTunes/App/MoodTunesApp.swift
@@ -5,38 +5,72 @@ import Combine
 struct MoodTunesApp: App {
     @StateObject var moodVM = MoodViewModel()
     @StateObject var libraryVM = LibraryViewModel()
+    @StateObject var shortcutHandler = ShortcutHandler()
+    @State private var selectedTab = 0
 
     var body: some Scene {
         WindowGroup {
-            TabView {
+            TabView(selection: $selectedTab) {
                 HomeView()
                     .tabItem {
                         Label("Home", systemImage: "house.fill")
                     }
+                    .tag(0)
 
                 ChatView()
                     .tabItem {
                         Label("Sara", systemImage: "bubble.left.and.bubble.right.fill")
                     }
+                    .tag(1)
 
                 DiscoverView()
                     .tabItem {
                         Label("Discover", systemImage: "magnifyingglass")
                     }
+                    .tag(2)
 
                 LibraryView()
                     .tabItem {
                         Label("Library", systemImage: "music.note.list")
                     }
-                
+                    .tag(3)
+
                 MoodMapView()
                     .tabItem {
                         Label("MoodMap", systemImage: "calendar")
                     }
+                    .tag(4)
 
             }
             .environmentObject(moodVM)
             .environmentObject(libraryVM)
+            .environmentObject(shortcutHandler)
+            .onOpenURL { handleURL($0) }
+        }
+    }
+}
+
+extension MoodTunesApp {
+    func handleURL(_ url: URL) {
+        guard url.scheme == "moodtunes" else { return }
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+
+        switch url.host {
+        case "search":
+            if let query = components?.queryItems?.first(where: { $0.name == "situation" })?.value {
+                shortcutHandler.searchQuery = query
+            }
+            selectedTab = 2
+        case "chat":
+            if let message = components?.queryItems?.first(where: { $0.name == "message" })?.value {
+                shortcutHandler.chatMessage = message
+            }
+            selectedTab = 1
+        case "play":
+            shortcutHandler.playRequested = true
+            selectedTab = 3
+        default:
+            break
         }
     }
 }

--- a/MoodTunes/Info.plist
+++ b/MoodTunes/Info.plist
@@ -8,7 +8,16 @@
 	<string>Sara needs your mic to listen to you</string>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>This app uses your music to build personalized playlists</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>This app needs your location to suggest mood-based tracks</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>This app needs your location to suggest mood-based tracks</string>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>moodtunes</string>
+                        </array>
+                </dict>
+        </array>
 </dict>
 </plist>

--- a/MoodTunes/Models/ShortcutHandler.swift
+++ b/MoodTunes/Models/ShortcutHandler.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SwiftUI
+
+class ShortcutHandler: ObservableObject {
+    @Published var searchQuery: String?
+    @Published var chatMessage: String?
+    @Published var playRequested: Bool = false
+}

--- a/MoodTunes/Shortcuts/AppShortcuts.swift
+++ b/MoodTunes/Shortcuts/AppShortcuts.swift
@@ -1,0 +1,61 @@
+import AppIntents
+
+struct SearchSongsIntent: AppIntent {
+    static var title: LocalizedStringResource = "Search Songs"
+    static var description = IntentDescription("Find songs for a situation")
+
+    @Parameter(title: "Situation") var situation: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Search songs for \(\.$situation)")
+    }
+
+    static var openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        let encoded = situation.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let url = URL(string: "moodtunes://search?situation=\(encoded)")!
+        return .openURL(url)
+    }
+}
+
+struct TalkToSaraIntent: AppIntent {
+    static var title: LocalizedStringResource = "Talk to Sara"
+    static var description = IntentDescription("Start a conversation with Sara")
+
+    @Parameter(title: "Message", default: "Hey Sara") var message: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Talk to Sara about \(\.$message)")
+    }
+
+    static var openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        let encoded = message.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let url = URL(string: "moodtunes://chat?message=\(encoded)")!
+        return .openURL(url)
+    }
+}
+
+struct PlayRecommendedSongIntent: AppIntent {
+    static var title: LocalizedStringResource = "Play Recommended Song"
+    static var description = IntentDescription("Open MoodTunes to play a suggested track")
+
+    static var openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        let url = URL(string: "moodtunes://play")!
+        return .openURL(url)
+    }
+}
+
+struct MoodTunesShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        [
+            AppShortcut(intent: SearchSongsIntent(), phrases: ["Search songs for \(\.$situation)", "Find music for \(\.$situation)"]),
+            AppShortcut(intent: TalkToSaraIntent(), phrases: ["Talk to Sara about \(\.$message)", "Ask Sara \(\.$message)"]),
+            AppShortcut(intent: PlayRecommendedSongIntent(), phrases: ["Play recommended song in MoodTunes", "MoodTunes play my music"])
+        ]
+    }
+}

--- a/MoodTunes/Views/ChatView.swift
+++ b/MoodTunes/Views/ChatView.swift
@@ -15,6 +15,7 @@ struct ChatView: View {
     @State private var situation: String = ""
 
     @EnvironmentObject var libraryVM: LibraryViewModel
+    @EnvironmentObject var shortcutHandler: ShortcutHandler
     @StateObject private var speechRecognizer = SpeechRecognizer()
     @State private var isRecording = false
 
@@ -80,6 +81,11 @@ struct ChatView: View {
                 if isRecording {
                     inputText = newValue
                 }
+            }
+            .onReceive(shortcutHandler.$chatMessage.compactMap { $0 }) { message in
+                inputText = message
+                send()
+                shortcutHandler.chatMessage = nil
             }
         }
     }

--- a/MoodTunes/Views/DiscoverView.swift
+++ b/MoodTunes/Views/DiscoverView.swift
@@ -8,6 +8,7 @@ struct DiscoverView: View {
     @State private var results: [Track] = []
     @State private var isLoading = false
     @State private var selectedTrack: Track?
+    @EnvironmentObject var shortcutHandler: ShortcutHandler
 
     var body: some View {
         NavigationView {
@@ -74,6 +75,11 @@ struct DiscoverView: View {
                 }
             }
             .navigationTitle("MoodTunes")
+            .onReceive(shortcutHandler.$searchQuery.compactMap { $0 }) { text in
+                query = text
+                search()
+                shortcutHandler.searchQuery = nil
+            }
         }
     }
 

--- a/MoodTunes/Views/LibraryView.swift
+++ b/MoodTunes/Views/LibraryView.swift
@@ -20,8 +20,11 @@ struct SelectedTrack: Identifiable {
 
 struct LibraryView: View {
     @EnvironmentObject var libraryVM: LibraryViewModel
+    @EnvironmentObject var shortcutHandler: ShortcutHandler
     @State private var selection = Set<UUID>()
     @State private var editMode: EditMode = .inactive
+    @State private var autoPlay: Bool = false
+    @State private var autoTracks: [Track] = []
 
     var body: some View {
         NavigationStack {
@@ -72,6 +75,18 @@ struct LibraryView: View {
                         Image(systemName: "trash")
                     }
                 }
+            }
+            .onReceive(shortcutHandler.$playRequested) { value in
+                guard value else { return }
+                if let playlist = libraryVM.playlists.first,
+                   !playlist.tracks.isEmpty {
+                    autoTracks = playlist.tracks
+                    autoPlay = true
+                }
+                shortcutHandler.playRequested = false
+            }
+            .sheet(isPresented: $autoPlay) {
+                NowPlayingView(tracks: autoTracks, currentIndex: 0)
             }
         }
     }


### PR DESCRIPTION
## Summary
- create `ShortcutHandler` observable object to handle incoming intents
- add `AppIntent` shortcuts to trigger search, talk, and play
- register `moodtunes://` URL scheme in Info.plist
- update `MoodTunesApp` to handle deep links and switch tabs
- react to shortcut events in `ChatView`, `DiscoverView`, and `LibraryView`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6871df94bfbc832a85e9e2992c3b37e9